### PR TITLE
feat(search): set search button color to secondary color

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -66,6 +66,7 @@ const setEventListeners = () => {
       week.style.color = selectedSecondaryColor;
       season.style.color = selectedSecondaryColor;
       searchBtn.style.background = selectedSecondaryColor;
+      searchBtn.style.color= selectedBackgroundColor;
       celebrationsLi.style.color = selectedSecondaryColor;
     });
     chrome.storage.sync.set(

--- a/calendar.js
+++ b/calendar.js
@@ -55,6 +55,29 @@ let backgroundColorPicker = document.getElementById("backgroundColorPicker");
 let saveColorButton = document.getElementById("saveColor");
 let resetColorButton = document.getElementById("resetColor");
 
+/**
+ * Determines a high-contrast text color (black or white) for a given background color.
+ *
+ * Extracts the RGB components from a hex color string, then calculates the
+ * relative luminance using the WCAG formula (0.299R + 0.587G + 0.114B) / 255,
+ * which weights each channel by human eye sensitivity. If the resulting
+ * luminance exceeds 0.5 (light background), black is returned; otherwise
+ * white is returned.
+ *
+ * @param {string} hexColor - A hex color string (e.g. "#513930")
+ * @returns {string} Either "#000000" or "#ffffff"
+ */
+const getContrastColor = (hexColor) => {
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+
+  // Calculate relative luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+  return luminance > 0.5 ? "#000000" : "#ffffff";
+};
+
 const setEventListeners = () => {
   // Save the selected color to chrome storage
   saveColorButton.addEventListener("click", () => {
@@ -66,7 +89,7 @@ const setEventListeners = () => {
       week.style.color = selectedSecondaryColor;
       season.style.color = selectedSecondaryColor;
       searchBtn.style.background = selectedSecondaryColor;
-      searchBtn.style.color= selectedBackgroundColor;
+      searchBtn.style.color= getContrastColor(selectedSecondaryColor);
       celebrationsLi.style.color = selectedSecondaryColor;
     });
     chrome.storage.sync.set(

--- a/index.css
+++ b/index.css
@@ -109,7 +109,7 @@ body {
   border-radius: 0.5rem;
   margin-left: 1rem;
   cursor: pointer;
-  font-weight: 500;
+  font-weight: bold;
   transition: all 0.3s ease;
 }
 


### PR DESCRIPTION
## Changes

- Added a `getContrast` function  in `calendar.js` to determine whether text needs to be black or white based off the calculated luminance of the color passed in
- Made the search button text bold within `index.css`

## Additional Context 
This is how the  search button text looks now
<img width="1876" height="832" alt="image" src="https://github.com/user-attachments/assets/c6332b80-56f3-451e-859c-ea15a6657bbe" />
